### PR TITLE
Added help command functionality

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="todx",
-    version="0.1.3",
+    version="0.1.4",
     author="xypnox",
     author_email="xypnox@gmail.com",
     description="A simple todo application",

--- a/todx/main.py
+++ b/todx/main.py
@@ -10,14 +10,14 @@ from . import parse_functions as pf
 from . import settings as stg
 
 def main_command():
+
     # Load datafile and parse arguments
     app_data_file = appdirs.user_data_dir('todx') + '/data.json'
 
     twrap = filehandler.load_file(app_data_file)
 
     args = sys.argv[1:]
-    # print('Arguments passed are : ', args)
-
+    #print('Arguments passed are : ', args)
     if len(args) == 0:
         args.append('task')
         pf.parse_task(twrap, args)
@@ -45,6 +45,11 @@ def main_command():
 
     elif args[0] == '--version' or args[0] == '-v':
         print('TodX v' + stg.version)
+
+    elif args[0] == '--help' or args[0] == '-h':
+        file_reader=open('todx/man.txt','r')
+        print(file_reader.read())
+
 
     elif args[0][0] == '+':
         args.insert(0, 'task')

--- a/todx/man.txt
+++ b/todx/man.txt
@@ -1,0 +1,12 @@
+usage: todx [option] ... [cmd]
+add or -a:  Adds an entry to your todo file.
+            todx add <your entry>
+mark or -m: Assigns a status to your todos
+            todx mark
+            Which todo you want to mark:<Select your option>
+            What is your new status: <Enter status>
+view      : View all your todos
+            todx view
+del       : Delets an item from your todo list
+            todx del
+version or --v: Version of the software


### PR DESCRIPTION
## Purpose
Added feature for ```--help``` or ```-h```  for giving the information about the available commands
## Approach
Made a file [man.txt](https://github.com/jay24rajput/todxpy/blob/help_command/todx/man.txt) which as all the commands listed to be printed to the CLI.

#### Open Questions and Pre-Merge TODOs
Verify all the commands. If any additions required, please let me know.

Closes issue #20 